### PR TITLE
Add default value for 'shots' in config.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -166,3 +166,14 @@ cython_debug/
 
 # nektos/act local GitHub actions tests
 .actrc
+
+# Due to environments
+.venv/
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Python specific environment files
+Source/

--- a/qstone/utils/utils.py
+++ b/qstone/utils/utils.py
@@ -212,6 +212,12 @@ def load_jobs(config_path, schema):
     """Loading a json file and checking it against the schema"""
     with open(config_path, "r", encoding="utf8") as _file:
         config = json.load(_file)
+    
+    # Set default values (100) for num_shots_min and num_shots_max if missing
+    for job in config["jobs"]:
+        job["num_shots_min"] = job.get("num_shots_min", 100)
+        job["num_shots_max"] = job.get("num_shots_max", 100)
+    
     return schema(pd.DataFrame.from_dict(config["jobs"], orient="columns"))
 
 

--- a/qstone/utils/utils.py
+++ b/qstone/utils/utils.py
@@ -212,12 +212,12 @@ def load_jobs(config_path, schema):
     """Loading a json file and checking it against the schema"""
     with open(config_path, "r", encoding="utf8") as _file:
         config = json.load(_file)
-    
+
     # Set default values (100) for num_shots_min and num_shots_max if missing
     for job in config["jobs"]:
         job["num_shots_min"] = job.get("num_shots_min", 100)
         job["num_shots_max"] = job.get("num_shots_max", 100)
-    
+
     return schema(pd.DataFrame.from_dict(config["jobs"], orient="columns"))
 
 

--- a/tests/data/generator/config_multi.json
+++ b/tests/data/generator/config_multi.json
@@ -4,15 +4,15 @@
   "qpu_ip_address": "0.0.0.0",
   "qpu_port": "55",
   "qpu_management": "LOCK",
-  "timeouts" : {
-      "http": 5,
-      "lock": 4
+  "timeouts": {
+    "http": 5,
+    "lock": 4
   },
   "jobs": [
     {
       "type": "VQE",
       "qubit_min": 2,
-      "qubit_max": 4, 
+      "qubit_max": 4,
       "num_shots_min": 2,
       "num_shots_max": 4,
       "nthreads": 2,
@@ -27,7 +27,7 @@
       "qubit_max": 4,
       "walltime": 1,
       "nthreads": 1,
-      "slurm/schedmd_opt": "--cpus-per-task=4" 
+      "slurm/schedmd_opt": "--cpus-per-task=4"
     }
   ],
   "users": [

--- a/tests/data/generator/config_single.json
+++ b/tests/data/generator/config_single.json
@@ -5,9 +5,9 @@
   "qpu_port": "55",
   "qpu_management": "LOCK",
   "lock_file": "my_lock.lock",
-  "timeouts" : {
-      "http": 5,
-      "lock": 4
+  "timeouts": {
+    "http": 5,
+    "lock": 4
   },
   "jobs": [
     {
@@ -28,7 +28,7 @@
       "num_shots_max": 4,
       "walltime": 1,
       "nthreads": 1,
-      "slurm/schedmd_opt": "--special_setting=4" 
+      "slurm/schedmd_opt": "--special_setting=4"
     }
   ],
   "users": [

--- a/tests/data/generator/config_single_custom_app.json
+++ b/tests/data/generator/config_single_custom_app.json
@@ -11,9 +11,9 @@
       "qubit_max": 4,
       "num_shots_min": 2,
       "num_shots_max": 4,
-       "walltime": 3,
+      "walltime": 3,
       "nthreads": 2,
-       "lsf/jsrun_opt": "-nnodes=4"
+      "lsf/jsrun_opt": "-nnodes=4"
     },
     {
       "type": "RB",
@@ -23,7 +23,7 @@
       "num_shots_max": 4,
       "walltime": 3,
       "nthreads": 2,
-      "slurm/schedmd_opt": "--cpus-per-task=4" 
+      "slurm/schedmd_opt": "--cpus-per-task=4"
     },
     {
       "type": "custom1.Custom1",
@@ -34,9 +34,8 @@
       "num_shots_max": 4,
       "walltime": 3,
       "nthreads": 2,
-      "slurm/schedmd_opt": "--cpus-per-task=4" 
+      "slurm/schedmd_opt": "--cpus-per-task=4"
     }
-
   ],
   "users": [
     {
@@ -46,7 +45,7 @@
         "VQE": 0.05,
         "RB": 0.44,
         "PyMatching": 0.01,
-        "custom1.Custom1" : 0.50
+        "custom1.Custom1": 0.50
       }
     }
   ]


### PR DESCRIPTION
This PR adds a default value of 100 for the shots field in config.json, making it an optional entry. If shots is not specified in the configuration, it will default to 100.
