### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -4,6 +4,7 @@ permissions:
   contents: read
 
 # Controls when the action will run.
+on:
   push:
 
 jobs:


### PR DESCRIPTION
Potential fix for [https://github.com/riverlane/QStone/security/code-scanning/3](https://github.com/riverlane/QStone/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root level of the workflow to define default permissions for all jobs. This ensures that the `build` job, which currently lacks explicit permissions, will inherit these minimal permissions. The `publish` job already has its own `permissions` block, so it will not be affected by the root-level permissions.

The minimal permissions required for the `build` job are `contents: read`, as it only needs to read the repository contents to build the distribution. We will add this to the root of the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
